### PR TITLE
decimal >=2.0.0 break

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   # https://github.com/a14n/dart-decimal
-  decimal: ">=1.0.0 <3.0.0"
+  decimal: ">=1.0.0 <2.0.0"
   # https://github.com/dart-lang/crypto
   crypto: ">=3.0.0 <5.0.0"
   # https://github.com/dart-lang/convert


### PR DESCRIPTION
* Return type changed https://github.com/a14n/dart-decimal/commit/d03e865f30e81889ea85d1899d974cc3d0c39671#diff-f1c57ad606ae249192fad6d5c8d3837d2af89a04d1a03a8b6067c51f1bc1671dR110
* `toInt` deleted https://github.com/a14n/dart-decimal/commit/d03e865f30e81889ea85d1899d974cc3d0c39671#diff-f1c57ad606ae249192fad6d5c8d3837d2af89a04d1a03a8b6067c51f1bc1671dL176

If we want use > 2.0.0, we should to release v3.
